### PR TITLE
Do not call calculateExposure() if AEL is active

### DIFF
--- a/LEX/LEX.ino
+++ b/LEX/LEX.ino
@@ -185,7 +185,7 @@ void onButtonPushed(int button)
 void loop()
 {
     if (awake) {
-        if (timeSinceExposure > EXPOSURE_CALC_INTERVAL) {
+        if (!ael && timeSinceExposure > EXPOSURE_CALC_INTERVAL) {
             exposureDurationSeconds = calculateExposure();
             updateDisplay(exposureDurationSeconds);
             timeSinceExposure = 0;
@@ -321,9 +321,6 @@ uint16_t getLux()
 */
 float calculateExposure()
 {
-    if (ael) {
-        return;
-    }
     uint16_t lux = getLux();
     float currentISO = FILM_SENSITIVITY_TABLE[sensitivityIndex];
     float currentAperture = APERTURE_TABLE[apertureIndex];


### PR DESCRIPTION
The function `calculateExposure()` started with:

```c++
    if (ael) {
        return;
    }
```

It is, however, incorrect to return no value from a function that is supposed to return a float. This commit moves the AEL test from this function to the caller (namely, `loop()`), which avoids this problem.