### PR TITLE
Test the three gyro components

### DIFF
--- a/LEX/LEX.ino
+++ b/LEX/LEX.ino
@@ -212,7 +212,7 @@ void shootFrame(float exposureTimeSeconds)
                 return; // The user gave up before we could shoot the frame
             }
             accelgyro.getMotion6(&ax, &ay, &az, &gx, &gy, &gz);
-            if (abs(gx) > 10 || abs(gy) > 10 || abs(gx) > 10) {
+            if (abs(gx) > 10 || abs(gy) > 10 || abs(gz) > 10) {
                 continue;
             } else {
                 break;


### PR DESCRIPTION
The anti shake code would test the x gyro component twice, and it would never test the z component. This was presumably a typo.