### PR TITLE
Control the exposure time with delayMicroseconds()

### DIFF
--- a/LEX/LEX.ino
+++ b/LEX/LEX.ino
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <BH1750.h>
@@ -278,18 +279,18 @@ void deprimeShutters()
 */
 void fireShutters(float exposureTimeSeconds)
 {
-    int microseconds = exposureTimeSeconds * 1000000;
-    int milliseconds = exposureTimeSeconds * 1000;
+    unsigned int microseconds = exposureTimeSeconds * 1000000;
+    unsigned long milliseconds = exposureTimeSeconds * 1000;
     Serial.print("ms");
     Serial.println(milliseconds);
 
     digitalWrite(frontCurtainPin, LOW); // Drop front curtain
 
-    // if (microseconds > 16000) {
-    delay(milliseconds);
-    //} else {
-    //   delayMicroseconds(microseconds);
-    // }
+    if (milliseconds >= UINT_MAX / 1000) {
+        delay(milliseconds);
+    } else {
+        delayMicroseconds(microseconds);
+    }
 
     digitalWrite(rearCurtainPin, HIGH); // Drop rear curtain
     delay(10); // activation time time for coil


### PR DESCRIPTION
The program is supposed to support exposure times as short as 1/8000 s. The one millisecond resolution of `delay()` is unsuitable for the shortest of those exposure times. `delayMicroseconds()`, on the other hand, provides 4&nbsp;microsecond resolution for delays as long as 65.535&nbsp;ms. Delays longer than 65&nbsp;ms are achieved with delay().